### PR TITLE
Check existence before creating a new directory

### DIFF
--- a/py/selenium/webdriver/firefox/firefox_profile.py
+++ b/py/selenium/webdriver/firefox/firefox_profile.py
@@ -255,7 +255,8 @@ class FirefoxProfile(object):
             compressed_file = zipfile.ZipFile(addon, 'r')
             for name in compressed_file.namelist():
                 if name.endswith('/'):
-                    os.makedirs(os.path.join(tmpdir, name))
+                    if not os.path.isdir(os.path.join(tmpdir, name)):
+                        os.makedirs(os.path.join(tmpdir, name))
                 else:
                     if not os.path.isdir(os.path.dirname(os.path.join(tmpdir, name))):
                         os.makedirs(os.path.dirname(os.path.join(tmpdir, name)))


### PR DESCRIPTION
If the name ends with '/', check if the tmp directory already exists before trying to create it. Previously, it would result in an OS Error exception being thrown.